### PR TITLE
Fix the repo URL for msgpack-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "0.1.1",
   "repository": {
     "type": "git",
-    "url": "git://github.com/creationix/msgpack.git"
+    "url": "git://github.com/creationix/msgpack-js.git"
   },
   "main": "msgpack.js",
   "engines": {


### PR DESCRIPTION
Probably just a typo but thought it might help for those of us who 'npm show <package>' to see more info about the project before hitting the GitHub page. :)
