### PR TITLE
set minimum version of node

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "type": "git",
     "url": "git://github.com/chakrit/msgpack-js.git"
   },
+  "engines": {
+    "node" : ">0.7.0"
+  },
   "main": "msgpack.js",
   "dependencies": {
     "bops": "~1.0.0"


### PR DESCRIPTION
Talked about this previously where using the newer version of bops caused the node 0.6 test to fail.  To counteract this, I am setting the minimum version of node to 0.7